### PR TITLE
Add a workaround for kubernetes/kubernetes#60741

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ after_success:
 - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 # Download minikube.
 - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-- sudo minikube start --vm-driver=none --kubernetes-version=${KUBE_VERSION}
+- sudo minikube start --vm-driver=none --kubernetes-version=${KUBE_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC
 # Fix the kubectl context, as it's often stale.
 - minikube update-context
 # Wait for Kubernetes to be up and ready.

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,14 +41,18 @@ RUN set -ex && \
 
 COPY entrypoint.sh /
 
-COPY --from=0 /kubectl kubernetes/_output/local/bin/linux/amd64/
-COPY --from=0 /dumb-init /
+COPY --from=0 /kubectl /usr/local/bin/
+COPY --from=0 /dumb-init /usr/local/bin/
 COPY --from=0 /kubernetes/cluster/update-storage-objects.sh kubernetes/cluster/
 COPY --from=0 /kubernetes/cluster/lib kubernetes/cluster/lib/
 COPY --from=0 /kubernetes/hack/lib kubernetes/hack/lib/
 COPY --from=1 /kput /usr/local/bin/
 
+RUN set -ex && \
+    mkdir -p /kubernetes/_output/local/bin/linux/amd64 && \
+    ln -s /usr/local/bin/kubectl /kubernetes/_output/local/bin/linux/amd64/kubectl
+
 WORKDIR /kubernetes
 
-ENTRYPOINT ["/dumb-init", "/entrypoint.sh"]
+ENTRYPOINT ["dumb-init", "/entrypoint.sh"]
 CMD ["cluster/update-storage-objects.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -e -o pipefail
 
+if [[ "$(kubectl get clusterrolebinding system:node -o="go-template={{.subjects}}")" == "<no value>" ]]; then
+  echo "Deleting clusterrolebinding/system:node. This is a workaround for https://github.com/kubernetes/kubernetes/pull/60741."
+  kubectl delete clusterrolebinding system:node
+fi
+
 if [[ -n "$DEBUG" ]]; then
   exec bash -x "$@"
 fi


### PR DESCRIPTION
This PR adds a workaround which deletes `clusterrolebinding/system:node` if its subjects is null. You can verify this PR with the following steps:
```
$ docker run -v ${HOME}/.kube:/.kube -v ${HOME}/.minikube:${HOME}/.minikube -e KUBECONFIG=/.kube/config zlabjp/update-storage-objects:latest
Deleting clusterrolebinding/system:node. This is a workaround for https://github.com/kubernetes/kubernetes/pull/60741.
clusterrolebinding "system:node" deleted
All objects updated successfully!!
```

See https://github.com/kubernetes/kubernetes/pull/60741 for more details.