### PR TITLE
Fix .travis.yml to be able to push an image correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ after_success:
 
 deploy:
   provider: script
-  script: DOCKER_TAG="${TRAVIS_TAG}" scripts/docker-push.sh
+  script: echo "${DOCKER_PASSWORD}" | docker login -u="${DOCKER_USERNAME}" --password-stdin && DOCKER_TAG="${TRAVIS_TAG}" scripts/docker-push.sh
   on:
     branch: master
     tags: true

--- a/scripts/docker-push.sh
+++ b/scripts/docker-push.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux
 
 DOCKER_TAG="$(echo "${DOCKER_TAG}" | sed -e "s/^v//")"
 
-echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-docker push zlabjp/update-storage-objects:latest
+docker tag zlabjp/update-storage-objects:latest zlabjp/update-storage-objects:${DOCKER_TAG}
 docker push zlabjp/update-storage-objects:${DOCKER_TAG}


### PR DESCRIPTION
This PR fixes `.travis.yml` to be able to push an image correctly. Currently CI fails as follows:
```
Deploying application
scripts/docker-push.sh: line 7: DOCKER_PASSWORD: unbound variable
Error: Cannot perform an interactive login from a non TTY device
```

See https://travis-ci.org/zlabjp/update-storage-objects/jobs/365942328#L1044-L1046.