### PR TITLE
Upgrade debian-base to 0.3.2 for CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/debian-base-amd64:0.3
+FROM k8s.gcr.io/debian-base-amd64:0.3.2
 
 ARG KUBE_VERSION=v1.11.0
 ARG DUMB_INIT_VERSION=1.2.1


### PR DESCRIPTION
This PR upgrades debian-base to 0.3.2 for CVEs.