### PR TITLE
Bump the version to v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ update-storage-objects is a container image which contains patched `cluster/upda
 You can run this image in your local environment:
 
 ```
-docker run -v $HOME/.kube:/.kube -e KUBECONFIG=/.kube/config zlabjp/update-storage-objects:1.4.0
+docker run -v $HOME/.kube:/.kube -e KUBECONFIG=/.kube/config zlabjp/update-storage-objects:1.5.0
 ```
 
 You can also run this image from inside your cluster:

--- a/deploy/update-storage-objects-1.12.yaml
+++ b/deploy/update-storage-objects-1.12.yaml
@@ -28,5 +28,5 @@ spec:
       serviceAccountName: storage-objects-updater
       containers:
       - name: update-storage-objects
-        image: zlabjp/update-storage-objects:1.4.0
+        image: zlabjp/update-storage-objects:1.5.0
       restartPolicy: Never

--- a/deploy/update-storage-objects-1.13.yaml
+++ b/deploy/update-storage-objects-1.13.yaml
@@ -28,5 +28,5 @@ spec:
       serviceAccountName: storage-objects-updater
       containers:
       - name: update-storage-objects
-        image: zlabjp/update-storage-objects:1.4.0
+        image: zlabjp/update-storage-objects:1.5.0
       restartPolicy: Never

--- a/deploy/update-storage-objects.yaml
+++ b/deploy/update-storage-objects.yaml
@@ -28,5 +28,5 @@ spec:
       serviceAccountName: storage-objects-updater
       containers:
       - name: update-storage-objects
-        image: zlabjp/update-storage-objects:1.4.0
+        image: zlabjp/update-storage-objects:1.5.0
       restartPolicy: Never


### PR DESCRIPTION
This PR bumps the version of update-storage-objects to v1.5.0. This release contains the below changes:

* Upgrade vendors to Kubernetes 1.15 (#24) a36c901 (O. Yuanying)
* Change to download a binary of kind instead of building from source (#22) b79f321 (Kazuki Suda)
* Add skip error option (#21) 24c252f (uesyn)

I'll create the `v1.5.0` git tag after this PR is merged.